### PR TITLE
Fix bug when detecting OS

### DIFF
--- a/texliveonfly.py
+++ b/texliveonfly.py
@@ -34,7 +34,7 @@ defaultSpeechSetting = "never"
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/copyleft/gpl.html>.
 
-import re, subprocess, os, time,  optparse, sys, shlex
+import re, subprocess, platform, os, time,  optparse, sys, shlex
 
 scriptName = os.path.basename(__file__)     #the name of this script file
 py3 = sys.version_info[0]  >= 3
@@ -92,7 +92,7 @@ def generateSudoer(this_terminal_only = False,  tempDirectory = os.path.join(os.
         if this_terminal_only:
             process = subprocess.Popen( ['sudo'] + shlex.split(bashCommand) )
             process.wait()
-        elif os.name == "mac":
+        elif platform.system() == 'Darwin':
             process = subprocess.Popen(['osascript'], stdin=subprocess.PIPE )
             process.communicateStr( '''do shell script "{0}" with administrator privileges'''.format(bashCommand) )
         else:
@@ -132,7 +132,7 @@ def generateSpeakers(speech_setting):
         return (doNothing , doNothing)
 
     try:
-        if os.name == "mac":
+        if platform.system() == 'Darwin':
             speaker = subprocess.Popen(['say'], stdin=subprocess.PIPE )
         else:
             speaker = subprocess.Popen(['espeak'], stdin=subprocess.PIPE )


### PR DESCRIPTION
I think this fixes #2, according to [this blog](http://nowhereland.it/blog/2014/06/20/texliveonfly-wont-escalate-privileges-on-mac-os-x). The change at line 95 is necessary (at least on El Capitan), but I have no idea how to verify the necessity of the change at line 135, because

``` shell
texliveonfly main.tex
```

works without that change. I made that change believing that there is no more reasons to test `os.name` against `"mac"`.
